### PR TITLE
Changed how imports work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -407,6 +407,24 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@babylonjs/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-4pEKPEu14qRdqH5qatfmns/iHFHmujDI22SXkHIlJhTT0WgJH4I8IN1fPw9sU6jSCH2ul76Lpbi2zREvfrEDQA==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "@babylonjs/gui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@babylonjs/gui/-/gui-4.1.0.tgz",
+      "integrity": "sha512-H4+zkIMGQlqJ8r3KNlI1fY31v3AssauY7/IMXzl4GloXqmELE+A46h85q/fzY+0SPzXlD4lE0i3BqXkTIUKw+g==",
+      "dev": true,
+      "requires": {
+        "@babylonjs/core": "4.1.0",
+        "tslib": "^1.10.0"
+      }
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -1284,11 +1302,6 @@
         "babel-plugin-jest-hoist": "^26.2.0",
         "babel-preset-current-node-syntax": "^0.1.2"
       }
-    },
-    "babylonjs": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/babylonjs/-/babylonjs-4.1.0.tgz",
-      "integrity": "sha512-MnaH1BQIL+PYgqGaAvGVdP8yd7nM1j6sbQi/K/6+RlkHPxIETW2NbjqxiW7Sywgy7r3PwqWT/gxG4Bz95Z6/yA=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -5749,6 +5762,11 @@
           "dev": true
         }
       }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/nbduke/Inscribe.js#readme",
   "devDependencies": {
+    "@babylonjs/gui": "^4.1.0",
     "@types/jest": "^26.0.8",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.27",
@@ -33,7 +34,7 @@
     "typescript": "^3.9.2"
   },
   "dependencies": {
-    "babylonjs": "^4.1.0",
+    "@babylonjs/core": "^4.1.0",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.19"
   }

--- a/src/core/input/InputEventArgs.ts
+++ b/src/core/input/InputEventArgs.ts
@@ -1,4 +1,4 @@
-import { AbstractMesh, Ray, StickValues, Vector3 } from 'babylonjs';
+import { AbstractMesh, Ray, StickValues, Vector3 } from '@babylonjs/core';
 
 import {
   InputEvent,

--- a/src/core/objects/Box.ts
+++ b/src/core/objects/Box.ts
@@ -1,4 +1,4 @@
-import { Scene, VertexData } from 'babylonjs';
+import { Scene, VertexData } from '@babylonjs/core';
 
 import Shape from './Shape';
 

--- a/src/core/objects/Cylinder.ts
+++ b/src/core/objects/Cylinder.ts
@@ -1,4 +1,4 @@
-import { Scene, VertexData } from 'babylonjs';
+import { Scene, VertexData } from '@babylonjs/core';
 
 import Shape from './Shape';
 

--- a/src/core/objects/Disc.ts
+++ b/src/core/objects/Disc.ts
@@ -1,4 +1,4 @@
-import { Scene, VertexData } from 'babylonjs';
+import { Scene, VertexData } from '@babylonjs/core';
 
 import Shape from './Shape';
 

--- a/src/core/objects/ModelLoader.ts
+++ b/src/core/objects/ModelLoader.ts
@@ -5,7 +5,7 @@ import {
   SceneLoaderProgressEvent,
   TransformNode,
   Vector3
-} from 'babylonjs';
+} from '@babylonjs/core';
 
 import Event, { IEvent } from '../events/Event';
 

--- a/src/core/objects/Plane.ts
+++ b/src/core/objects/Plane.ts
@@ -1,4 +1,4 @@
-import { Scene, VertexData } from 'babylonjs';
+import { Scene, VertexData } from '@babylonjs/core';
 
 import Shape from './Shape';
 

--- a/src/core/objects/Shape.ts
+++ b/src/core/objects/Shape.ts
@@ -1,4 +1,4 @@
-import { Mesh, Scene, VertexData } from 'babylonjs';
+import { Mesh, Scene, VertexData } from '@babylonjs/core';
 import { isEqual, assign, cloneDeep } from 'lodash';
 
 export default class Shape<TProps> extends Mesh {

--- a/src/core/objects/Sphere.ts
+++ b/src/core/objects/Sphere.ts
@@ -1,4 +1,4 @@
-import { Scene, VertexData } from 'babylonjs';
+import { Scene, VertexData } from '@babylonjs/core';
 
 import Shape from './Shape';
 

--- a/src/core/objects/UpdatableTexture.ts
+++ b/src/core/objects/UpdatableTexture.ts
@@ -2,7 +2,7 @@ import {
   Observable,
   Scene,
   Texture
-} from 'babylonjs';
+} from '@babylonjs/core';
 
 /**
  * Improves Babylon's `Texture` class with consistent loading, loaded, and error observables

--- a/src/declarative/tests/CodeGen.test.ts
+++ b/src/declarative/tests/CodeGen.test.ts
@@ -7,7 +7,9 @@ describe('Code generation', () => {
   it.skip('can translate a valid XML document into a text file', async () => {
     return readFile('./src/declarative/tests/TestValid.xml').then(xmlStr => {
       const xml: Document = parseXml(xmlStr, { noblanks: true });
-      const documentTranslator: DocumentTranslator = new DocumentTranslator('babylonjs', '../../index');
+      const documentTranslator: DocumentTranslator = new DocumentTranslator({
+        inscribe: '../../index'
+      });
       const fileOutput: string = documentTranslator.translate(xml);
       return writeFile('./src/declarative/tests/Valid.ts', fileOutput);
     });

--- a/src/declarative/tests/TestValid.xml
+++ b/src/declarative/tests/TestValid.xml
@@ -144,7 +144,7 @@
           text="{this.viewModel.pageHeaderText}"
           horizontalAlignment="{Control.HORIZONTAL_ALIGNMENT_CENTER}"
           fontSize="125px"
-          fontWeight="100"
+          fontWeight="100px"
         />
       </Ellipse>
     </FullScreen>

--- a/src/declarative/translators/AttributeTranslator.test.ts
+++ b/src/declarative/translators/AttributeTranslator.test.ts
@@ -6,7 +6,8 @@ import { IObjectNames } from './ObjectNames';
 
 describe('AttributeTranslator', () => {
   const importsTracker: IImportsTracker = {
-    babylon: new Set(),
+    babylonCore: new Set(),
+    babylonGui: new Set(),
     inscribe: new Set(),
     lodash: new Set()
   };
@@ -118,7 +119,7 @@ describe('AttributeTranslator', () => {
     it('adds Babylon import if object is parsed', () => {
       const attribute: Attribute = createAttribute('background', '#AF103D');
       createUnit().translate(attribute, objectName);
-      expect(importsTracker.babylon).toContain('Color3');
+      expect(importsTracker.babylonCore).toContain('Color3');
     });
 
     it('will not parse primitive if doNotParsePrimitives option is set', () => {
@@ -279,7 +280,7 @@ describe('AttributeTranslator', () => {
 
     it('adds Babylon import if object is parsed', () => {
       createUnit().extractExpressionFromTypeAndValue('Color4', '0,0.23,0.59,1');
-      expect(importsTracker.babylon).toContain('Color4');
+      expect(importsTracker.babylonCore).toContain('Color4');
     });
 
     it('surrounds the value in quotes if not an expression and type is string', () => {

--- a/src/declarative/translators/AttributeTranslator.ts
+++ b/src/declarative/translators/AttributeTranslator.ts
@@ -151,7 +151,7 @@ export default class AttributeTranslator {
   }
 
   private _parseObject(type: string, value: string): string {
-    this._importsTracker.babylon.add(type);
+    this._importsTracker.babylonCore.add(type);
     if (type.startsWith('Color') && value.startsWith('#')) {
       return `${type}.FromHexString('${value}')`;
     } else {

--- a/src/declarative/translators/GuiTranslator.ts
+++ b/src/declarative/translators/GuiTranslator.ts
@@ -41,8 +41,8 @@ export default class GuiTranslator {
   }
 
   public translate(guisSection: Element): void {
-    this._importsTracker.babylon.add('AdvancedDynamicTexture');
-    this._importsTracker.babylon.add('Control');
+    this._importsTracker.babylonGui.add('AdvancedDynamicTexture');
+    this._importsTracker.babylonGui.add('Control');
     guisSection.childNodes().forEach(guiElement => {
       if (guiElement.name() === 'FullScreen') {
         this._translateFullScreenGui(guiElement);
@@ -123,7 +123,7 @@ export default class GuiTranslator {
     initMethod: MethodBuilder
   ): void {
     const controlType: string = controlElement.name();
-    this._importsTracker.babylon.add(controlType);
+    this._importsTracker.babylonGui.add(controlType);
     const objectNames: IObjectNames = getObjectNames(controlType, controlElement.attr('name')?.value());
     declareObject(controlType, objectNames, initMethod.name !== this._memberNames.init, this._class);
 

--- a/src/declarative/translators/MaterialTranslator.ts
+++ b/src/declarative/translators/MaterialTranslator.ts
@@ -79,7 +79,7 @@ export default class MaterialTranslator {
     nodeName?: string
   ): void {
     const materialType: string = materialElement.name();
-    this._importsTracker.babylon.add(materialType);
+    this._importsTracker.babylonCore.add(materialType);
     initMethod.addToBody(
       `this.${objectNames.privateName} = new ${materialType}('${objectNames.publicName}', this.${this._memberNames.scene});`
     );
@@ -119,7 +119,7 @@ export default class MaterialTranslator {
     const ensureMethod: MethodBuilder = new MethodBuilder(ensureMethodName, 'Texture', 'private');
     this._class.addMethod(ensureMethod);
     this._referenceableObjects.textures.set(textureName, ensureMethod); // replace init method with ensure method
-    this._importsTracker.babylon.add('Texture');
+    this._importsTracker.babylonCore.add('Texture');
     materialInfo.initMethod.addToBody(
       `this.${materialInfo.name}.${materialInfo.textureSlot} = this.${ensureMethodName}();`
     );

--- a/src/declarative/translators/NodeTranslator.ts
+++ b/src/declarative/translators/NodeTranslator.ts
@@ -77,7 +77,7 @@ export default class NodeTranslator {
 
   private _translateTransformNode(element: Element, parentName: string, initMethod: MethodBuilder): void {
     const nodeType: string = element.name();
-    this._importsTracker.babylon.add(nodeType);
+    this._importsTracker.babylonCore.add(nodeType);
     const objectNames: IObjectNames = getObjectNames(nodeType, element.attr('name')?.value());
     declareObject(nodeType, objectNames, initMethod.name !== this._memberNames.init, this._class);
 
@@ -161,7 +161,7 @@ export default class NodeTranslator {
     const ensureMethod: MethodBuilder = new MethodBuilder(ensureMethodName, 'Material', 'private');
     this._class.addMethod(ensureMethod);
     this._referenceableObjects.materials.set(materialName, ensureMethod); // replace init method with ensure method
-    this._importsTracker.babylon.add('Material');
+    this._importsTracker.babylonCore.add('Material');
     nodeInitMethod.addToBody(
       `this.${nodeName}.material = this.${ensureMethodName}();`
     );


### PR DESCRIPTION
Switched from 'babylonjs' to '@babylonjs/core' and '@babylonjs/gui', enabling me to test code generation more fully. Also changed how users of `DocumentTranslator` specify import libs.